### PR TITLE
Fixed  typos on Interview 01

### DIFF
--- a/Interview/01_Facebook_Advertiser_Status/README.md
+++ b/Interview/01_Facebook_Advertiser_Status/README.md
@@ -98,12 +98,12 @@ mysql> SELECT * FROM Advertiser;
 +----+---------+-----------+
 |  1 | bing    | CHURN     |
 |  2 | yahoo   | EXISTING  |
-|  3 | alibaba | CHURN     |
-|  4 | baidu   | EXISTING  |
-|  5 | target  | CHURN     |
-|  6 | tesla   | RESURRECT |
-|  7 | morgan  | CHURN     |
-|  8 | chase   | EXISTING  |
+|  3 | alibaba | EXISTING  |
+|  4 | baidu   | CHURN     |
+|  5 | target  | RESURRECT |
+|  6 | tesla   | CHURN     |
+|  7 | morgan  | EXISTING  |
+|  8 | chase   | CHURN     |
 +----+---------+-----------+
 8 rows in set (0.00 sec)
 ```
@@ -130,13 +130,13 @@ SELECT * FROM Advertiser;
 +----+---------+-----------+
 |  1 | bing    | CHURN     |
 |  2 | yahoo   | EXISTING  |
-|  3 | alibaba | CHURN     |
-|  4 | baidu   | EXISTING  |
-|  5 | target  | CHURN     |
-|  6 | tesla   | RESURRECT |
-|  7 | morgan  | CHURN     |
-|  8 | chase   | EXISTING  |
-| 10 | fitdata | NEW       |
+|  3 | alibaba | EXISTING  |
+|  4 | baidu   | CHURN     |
+|  5 | target  | RESURRECT |
+|  6 | tesla   | CHURN     |
+|  7 | morgan  | EXISTING  |
+|  8 | chase   | CHURN     |
+|  9 | fitdata | NEW       |
 +----+---------+-----------+
 9 rows in set (0.00 sec)
 ```

--- a/Interview/01_Facebook_Advertiser_Status/db.sql
+++ b/Interview/01_Facebook_Advertiser_Status/db.sql
@@ -34,7 +34,7 @@ CREATE TABLE `DailyPay` (
   `paid` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `DailyPay` (`id`, `user_id`, `paid_amount`) VALUES
+INSERT INTO `DailyPay` (`id`, `user_id`, `paid`) VALUES
 (1, 'yahoo', 45),
 (2, 'alibaba', 100),
 (3, 'target', 13),


### PR DESCRIPTION
Fixed a column name typo that blocks establishing the database inside `db.sql` : paid_amount/paid.

Fixed the print that did not present the true result after executing the statement: 
- Alibaba should be EXISTING
- Baidu should be CHURN
- Target should be RESURRECT
- Tesla should be CHURN
- Morgan should be EXISTING
- Chase should be CHURN