### PR TITLE
Fix typos on interview 09

### DIFF
--- a/Interview/09_Consecutive_Active_Users/README.md
+++ b/Interview/09_Consecutive_Active_Users/README.md
@@ -278,10 +278,7 @@ JOIN tmp AS d5
   AND d0.user_id = d5.user_id
 JOIN tmp AS d6
   ON DATEDIFF(@now, d6.ts) = 6
-  AND d0.user_id = d6.user_id
-JOIN tmp AS d7
-  ON DATEDIFF(@now, d7.ts) = 7
-  AND d0.user_id = d7.user_id;
+  AND d0.user_id = d6.user_id;
 ```
 
 ```sql
@@ -300,7 +297,6 @@ SELECT
   ,DATEDIFF(@now, LAG(ts, 4) OVER w) AS day_from_pre4
   ,DATEDIFF(@now, LAG(ts, 5) OVER w) AS day_from_pre5
   ,DATEDIFF(@now, LAG(ts, 6) OVER w) AS day_from_pre6
-  ,DATEDIFF(@now, LAG(ts, 7) OVER w) AS day_from_pre7
 FROM Login_distinct
 WINDOW w AS (PARTITION BY user_id ORDER BY ts)
 )
@@ -312,8 +308,7 @@ WHERE ts=@now
   AND day_from_pre3 = 3
   AND day_from_pre4 = 4
   AND day_from_pre5 = 5
-  AND day_from_pre6 = 6
-  AND day_from_pre7 = 7;
+  AND day_from_pre6 = 6;
 ```
 
 See full solution [here](solution.sql)

--- a/Interview/09_Consecutive_Active_Users/README.md
+++ b/Interview/09_Consecutive_Active_Users/README.md
@@ -224,13 +224,17 @@ ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that 
 The correct implementation.
 ```sql
 SET @now = "2019-02-14";
-WITH tmp AS (
+WITH Login_distinct AS (
+  SELECT DISTINCT user_id,
+  ts
+  FROM Login
+), tmp AS (
 SELECT
   user_id
   ,ts
   ,DATEDIFF(@now, LAG(ts, 1) OVER w) AS day_from_pre1
   ,DATEDIFF(@now, LAG(ts, 2) OVER w) AS day_from_pre2
-FROM Login
+FROM Login_DISTINCT
 WINDOW w AS (PARTITION BY user_id ORDER BY ts)
 )
 SELECT user_id
@@ -282,9 +286,14 @@ JOIN tmp AS d7
 
 ```sql
 SET @now = "2019-02-14";
-WITH tmp AS (
+WITH Login_distinct AS (
+  SELECT DISTINCT user_id,
+  ts
+  FROM Login
+), tmp AS (
 SELECT
   user_id
+  ,ts
   ,DATEDIFF(@now, LAG(ts, 1) OVER w) AS day_from_pre1
   ,DATEDIFF(@now, LAG(ts, 2) OVER w) AS day_from_pre2
   ,DATEDIFF(@now, LAG(ts, 3) OVER w) AS day_from_pre3
@@ -292,7 +301,7 @@ SELECT
   ,DATEDIFF(@now, LAG(ts, 5) OVER w) AS day_from_pre5
   ,DATEDIFF(@now, LAG(ts, 6) OVER w) AS day_from_pre6
   ,DATEDIFF(@now, LAG(ts, 7) OVER w) AS day_from_pre7
-FROM Login
+FROM Login_distinct
 WINDOW w AS (PARTITION BY user_id ORDER BY ts)
 )
 SELECT user_id


### PR DESCRIPTION
* Add a pre-filter to remove duplicates in the window funtion approaches, otherwise `LAG` or `LEAD` won't work as expected. (Try `SET @now = "2019-02-09"` to see the edge case. It should return user_id `4`)
* When generalizing to 7 consecutive active days, it doesn't need to check the difference of date to `7`, as we are testing the 7th day to `@now`