### PR TITLE
Fix on interview 14 & 15

### DIFF
--- a/Interview/14_Facebook_Common_Friend/db.sql
+++ b/Interview/14_Facebook_Common_Friend/db.sql
@@ -24,7 +24,7 @@ INSERT INTO `Friendship` (`id`, `user_id`, `friend_id`) VALUES
 (6, 'bob', 'charles'),
 (7, 'bob', 'mary'),
 (8, 'david', 'sonny'),
-(9, 'charles', 'sonny');
+(9, 'charles', 'sonny'),
 (10, 'bob', 'sonny');
 
 ALTER TABLE `Friendship`

--- a/Interview/15_Facebook_People_You_May_Know/README.md
+++ b/Interview/15_Facebook_People_You_May_Know/README.md
@@ -10,10 +10,16 @@ ___
 This can be done with a cross join. Obviously we want to avoid matching a user with himself.
 
 ```sql
+WITH tmp AS (
+SELECT user_id, friend_id FROM Friendship
+UNION ALL
+SELECT friend_id, user_id FROM Friendship
+)
+
 SELECT * FROM
-(SELECT DISTINCT user_id FROM Friendship) AS a
+(SELECT DISTINCT user_id FROM tmp) AS a
 CROSS JOIN
-(SELECT DISTINCT user_id FROM Friendship) AS b
+(SELECT DISTINCT user_id FROM tmp) AS b
 ON a.user_id != b.user_id;
 ```
 ```
@@ -23,57 +29,89 @@ ON a.user_id != b.user_id;
 | bob     | alice   |
 | david   | alice   |
 | charles | alice   |
+| mary    | alice   |
+| sonny   | alice   |
 | alice   | bob     |
 | david   | bob     |
 | charles | bob     |
+| mary    | bob     |
+| sonny   | bob     |
 | alice   | david   |
 | bob     | david   |
 | charles | david   |
+| mary    | david   |
+| sonny   | david   |
 | alice   | charles |
 | bob     | charles |
 | david   | charles |
+| mary    | charles |
+| sonny   | charles |
+| alice   | mary    |
+| bob     | mary    |
+| david   | mary    |
+| charles | mary    |
+| sonny   | mary    |
+| alice   | sonny   |
+| bob     | sonny   |
+| david   | sonny   |
+| charles | sonny   |
+| mary    | sonny   |
 +---------+---------+
-12 rows in set (0.00 sec)
+30 rows in set (0.00 sec)
 ```
 
 Also, we don't want to recommend people who are already friends.
 
-```sql
-SELECT * FROM
-(SELECT DISTINCT user_id FROM Friendship) AS a
-CROSS JOIN
-(SELECT DISTINCT user_id FROM Friendship) AS b
-ON a.user_id != b.user_id
-AND (a.user_id, b.user_id) NOT IN (SELECT user_id, friend_id FROM Friendship)
-AND (b.user_id, a.user_id) NOT IN (SELECT user_id, friend_id FROM Friendship);
-```
-```
-+---------+---------+
-| user_id | user_id |
-+---------+---------+
-| charles | david   |
-| david   | charles |
-+---------+---------+
-2 rows in set (0.01 sec)
-```
-
-___
-### Step 2. Expand Two-way
-The rest is the same as the previous problem. Here I constructed a tmp table to exclude existing friendship, instead of using two *AND* clause.
 ```sql
 WITH tmp AS (
 SELECT user_id, friend_id FROM Friendship
 UNION ALL
 SELECT friend_id, user_id FROM Friendship
 )
+
+SELECT * FROM
+(SELECT DISTINCT user_id FROM tmp) AS a
+CROSS JOIN
+(SELECT DISTINCT user_id FROM tmp) AS b
+ON a.user_id != b.user_id
+AND (a.user_id, b.user_id) NOT IN (SELECT user_id, friend_id FROM tmp);
+```
+```
++---------+---------+
+| user_id | user_id |
++---------+---------+
+| sonny   | alice   |
+| charles | david   |
+| mary    | david   |
+| david   | charles |
+| mary    | charles |
+| david   | mary    |
+| charles | mary    |
+| sonny   | mary    |
+| alice   | sonny   |
+| mary    | sonny   |
++---------+---------+
+10 rows in set (0.00 sec)
+```
+
+___
+### Step 2. Expand Two-way
+The rest is the same as the previous problem.
+```sql
+WITH tmp AS (
+SELECT user_id, friend_id FROM Friendship
+UNION ALL
+SELECT friend_id, user_id FROM Friendship
+)
+
 SELECT 
 	a.user_id
 	,b.user_id
 	,af.friend_id AS common_friend
 FROM
-(SELECT DISTINCT user_id FROM Friendship) AS a
+(SELECT DISTINCT user_id FROM tmp) AS a
 CROSS JOIN
-(SELECT DISTINCT user_id FROM Friendship) AS b
+(SELECT DISTINCT user_id FROM tmp) AS b
 	ON a.user_id != b.user_id
 	AND (a.user_id, b.user_id) NOT IN (SELECT user_id, friend_id FROM tmp)
 JOIN tmp AS af
@@ -86,14 +124,30 @@ JOIN tmp AS bf
 +---------+---------+---------------+
 | user_id | user_id | common_friend |
 +---------+---------+---------------+
+| alice   | sonny   | bob           |
+| alice   | sonny   | charles       |
+| alice   | sonny   | david         |
 | david   | charles | sonny         |
-| david   | charles | alice         |
-| david   | charles | bob           |
 | charles | david   | sonny         |
 | charles | david   | alice         |
+| charles | mary    | alice         |
+| david   | charles | alice         |
+| david   | mary    | alice         |
+| mary    | charles | alice         |
+| mary    | david   | alice         |
+| david   | charles | bob           |
+| david   | mary    | bob           |
 | charles | david   | bob           |
+| charles | mary    | bob           |
+| mary    | david   | bob           |
+| mary    | charles | bob           |
+| mary    | sonny   | bob           |
+| sonny   | alice   | david         |
+| sonny   | alice   | charles       |
+| sonny   | alice   | bob           |
+| sonny   | mary    | bob           |
 +---------+---------+---------------+
-6 rows in set (0.00 sec)
+22 rows in set (0.01 sec)
 ```
 
 ___
@@ -106,14 +160,15 @@ SELECT user_id, friend_id FROM Friendship
 UNION ALL
 SELECT friend_id, user_id FROM Friendship
 )
+
 SELECT 
 	a.user_id
 	,b.user_id
 	,COUNT(*) AS common_friend
 FROM
-(SELECT DISTINCT user_id FROM Friendship) AS a
+(SELECT DISTINCT user_id FROM tmp) AS a
 CROSS JOIN
-(SELECT DISTINCT user_id FROM Friendship) AS b
+(SELECT DISTINCT user_id FROM tmp) AS b
 	ON a.user_id != b.user_id
 	AND (a.user_id, b.user_id) NOT IN (SELECT user_id, friend_id FROM tmp)
 JOIN tmp AS af
@@ -122,16 +177,19 @@ JOIN tmp AS bf
 	ON b.user_id = bf.user_id
 	AND bf.friend_id = af.friend_id
 GROUP BY a.user_id, b.user_id
+HAVING COUNT(*) >= 3
 ORDER BY common_friend DESC;
 ```
 ```
 +---------+---------+---------------+
 | user_id | user_id | common_friend |
 +---------+---------+---------------+
+| alice   | sonny   |             3 |
 | david   | charles |             3 |
 | charles | david   |             3 |
+| sonny   | alice   |             3 |
 +---------+---------+---------------+
-2 rows in set (0.00 sec)
+4 rows in set (0.00 sec)
 ```
 
 See solution [here](solution.sql).

--- a/Interview/15_Facebook_People_You_May_Know/solution.sql
+++ b/Interview/15_Facebook_People_You_May_Know/solution.sql
@@ -3,14 +3,15 @@ SELECT user_id, friend_id FROM Friendship
 UNION ALL
 SELECT friend_id, user_id FROM Friendship
 )
+
 SELECT 
 	a.user_id
 	,b.user_id
 	,COUNT(*) AS common_friend
 FROM
-(SELECT DISTINCT user_id FROM Friendship) AS a
+(SELECT DISTINCT user_id FROM tmp) AS a
 CROSS JOIN
-(SELECT DISTINCT user_id FROM Friendship) AS b
+(SELECT DISTINCT user_id FROM tmp) AS b
 	ON a.user_id != b.user_id
 	AND (a.user_id, b.user_id) NOT IN (SELECT user_id, friend_id FROM tmp)
 JOIN tmp AS af
@@ -19,4 +20,5 @@ JOIN tmp AS bf
 	ON b.user_id = bf.user_id
 	AND bf.friend_id = af.friend_id
 GROUP BY a.user_id, b.user_id
+HAVING COUNT(*) >= 3
 ORDER BY common_friend DESC;

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This section covers commonly tested concepts during interviews. Many notebooks a
 |12 | Invalid Search				| [MySQL](./Interview/12_Invalid_Search/README.md)    		   | __NULL__ handling, rate calculation |
 |13 | Text Confirmation				| [MySQL](./Interview/13_Text_Confirmation/README.md)          | Rate calculation |
 |14 | Facebook Common Friends		| [MySQL](./Interview/14_Facebook_Common_Friend/README.md)     | self join, three-way join |
-|15 | Facebook Recommend Friend		| [MySQL](./Interview/15_Facebook_Recommend_Friend/README.md)  | Self join, four-way join |
+|15 | Facebook Recommend Friend		| [MySQL](./Interview/15_Facebook_People_You_May_Know/README.md)  | Self join, four-way join |
 |16 | Instagram Common Follower		| [MySQL](./Interview/16_Instagram_Common_Follower/README.md)  | Self join, Directed edge |
 
 ---


### PR DESCRIPTION
*  Add a `tmp` table with two-way binding for the use of constructing a list of (`user_id`, `user_id`) base pairs by `CROSS JOIN`, so that it will contain all possible `user_id`s that may be missed in the previous approach. Check edge case: `alice` and `sonny`
*  Remove a semicolon in `db.sql` that blocks loading the last row in the dataset
* Fix a link to Interview 15 problem set